### PR TITLE
fix requestHTTP example

### DIFF
--- a/views/docs.dt
+++ b/views/docs.dt
@@ -458,14 +458,14 @@ block body
 					|
 					|void main()
 					|{
-					|	auto res = requestHTTP("http://google.com",
-					|			(scope req) {
-					|				/* could e.g. add headers here before sending*/
-					|			},
-					|			(scope res) {
-					|				logInfo("Response: %s", res.bodyReader.readAllUTF8());
-					|			}
-					|		);
+					|	requestHTTP("http://google.com",
+					|		(scope req) {
+					|			/* could e.g. add headers here before sending*/
+					|		},
+					|		(scope res) {
+					|			logInfo("Response: %s", res.bodyReader.readAllUTF8());
+					|		}
+					|	);
 					|}
 				.caption Example: Performing a simple HTTP request
 


### PR DESCRIPTION
The overload of [requestHTTP](http://vibed.org/api/vibe.http.client/requestHTTP) which takes a response callback has no return value.
