### PR TITLE
Fix typo in 'Function' examples.

### DIFF
--- a/views/templates.dt
+++ b/views/templates.dt
@@ -378,7 +378,7 @@ block body
 					body
 						- foreach(c; ["red", "green", "blue"])
 							- void repeat(string c)
-								|\#{c}-\#{c}\#{c}
+								|\#{c}-\#{c}-\#{c}
 							p
 								span(style='color: red;')
 									- repeat(c);


### PR DESCRIPTION
In the Diet template, a dash is missing.