### PR TITLE
Spelling fix (sessiom->session)

### DIFF
--- a/docs-0.7.17.json
+++ b/docs-0.7.17.json
@@ -19449,7 +19449,7 @@
 						}
 					],
 					"name": "destroy",
-					"comment": " Terminates the given sessiom.\n"
+					"comment": " Terminates the given session.\n"
 				},
 				{
 					"kind": "function",

--- a/docs-0.7.18.json
+++ b/docs-0.7.18.json
@@ -19867,7 +19867,7 @@
 							}
 						],
 						"name": "destroy",
-						"comment": " Terminates the given sessiom.\n"
+						"comment": " Terminates the given session.\n"
 					},
 					{
 						"kind": "function",

--- a/docs-0.7.19.json
+++ b/docs-0.7.19.json
@@ -20419,7 +20419,7 @@
 							}
 						],
 						"name": "destroy",
-						"comment": " Terminates the given sessiom.\n"
+						"comment": " Terminates the given session.\n"
 					},
 					{
 						"kind": "function",

--- a/docs-0.7.20.json
+++ b/docs-0.7.20.json
@@ -20826,7 +20826,7 @@
 							}
 						],
 						"name": "destroy",
-						"comment": " Terminates the given sessiom.\n"
+						"comment": " Terminates the given session.\n"
 					},
 					{
 						"kind": "function",

--- a/docs-0.7.21.json
+++ b/docs-0.7.21.json
@@ -27892,7 +27892,7 @@
 							}
 						],
 						"name": "destroy",
-						"comment": "Terminates the given sessiom.\n"
+						"comment": "Terminates the given session.\n"
 					},
 					{
 						"kind": "function",

--- a/docs-0.7.22.json
+++ b/docs-0.7.22.json
@@ -27907,7 +27907,7 @@
 							}
 						],
 						"name": "destroy",
-						"comment": "Terminates the given sessiom.\n"
+						"comment": "Terminates the given session.\n"
 					},
 					{
 						"kind": "function",

--- a/docs-0.7.23.json
+++ b/docs-0.7.23.json
@@ -28895,7 +28895,7 @@
 							}
 						],
 						"name": "destroy",
-						"comment": "Terminates the given sessiom.\n"
+						"comment": "Terminates the given session.\n"
 					},
 					{
 						"kind": "function",

--- a/docs-0.7.24.json
+++ b/docs-0.7.24.json
@@ -29773,7 +29773,7 @@
 					{
 						"name": "destroy",
 						"line": 194,
-						"comment": "Terminates the given sessiom.\n",
+						"comment": "Terminates the given session.\n",
 						"storageClass": [
 							"abstract"
 						],

--- a/docs-0.7.25.json
+++ b/docs-0.7.25.json
@@ -29768,7 +29768,7 @@
 					{
 						"name": "destroy",
 						"line": 194,
-						"comment": "Terminates the given sessiom.\n",
+						"comment": "Terminates the given session.\n",
 						"storageClass": [
 							"abstract"
 						],

--- a/docs-0.7.26.json
+++ b/docs-0.7.26.json
@@ -30520,7 +30520,7 @@
 					{
 						"name": "destroy",
 						"line": 189,
-						"comment": "Terminates the given sessiom.\n",
+						"comment": "Terminates the given session.\n",
 						"storageClass": [
 							"abstract"
 						],

--- a/docs.json
+++ b/docs.json
@@ -30520,7 +30520,7 @@
 					{
 						"name": "destroy",
 						"line": 189,
-						"comment": "Terminates the given sessiom.\n",
+						"comment": "Terminates the given session.\n",
 						"storageClass": [
 							"abstract"
 						],


### PR DESCRIPTION
I noticed a typo in the documentation (session spelled sessiom).  I made no other changes.