### PR TITLE
Update outdated jade project to pug

### DIFF
--- a/views/docs.dt
+++ b/views/docs.dt
@@ -306,7 +306,7 @@ block vibed.body
 			h3#html-templates Diet templates
 
 			p Vibe.d supports HTML templates with a syntax mostly compatible to
-				a.extern(href="http://jade-lang.com/", target="_blank") jade
+				a.extern(href="https://pugjs.org", target="_blank") Pug
 				| templates. They provide a concise way to dynamically generate the HTML code of the final web pages. D expressions and statements can be embedded and the full vibe.d API is available within templates.
 
 			p Templates should reside somewhere inside the 'views' folder of a project. They are then rendered using the

--- a/views/features.dt
+++ b/views/features.dt
@@ -223,7 +223,7 @@ block vibed.body
 			h3#diet-templates Compile-time "Diet" templates
 			img.leftFlow(src="images/feature_diet.png")
 
-			p vibe.d has built-in support for <a href="docs#html-templates">Diet HTML templates</a> based on the <a class="extern" href="http://jade-lang.com/" target="_blank">jade</a> template syntax known from node.js which in turn is based on <a class="extern" href="http://haml-lang.com/" target="_blank">Haml</a>. These templates remove all the syntax overhead that is inherent to HTML's tag based notation and also allow the inline specification of dynamic elements. Typically, these elements are written in a dynamic scripting language (JavaScript in case of jade).
+			p vibe.d has built-in support for <a href="docs#html-templates">Diet HTML templates</a> based on the <a class="extern" href="https://pugjs.org/" target="_blank">Pug</a> template syntax known from node.js which in turn is based on <a class="extern" href="http://haml-lang.com/" target="_blank">Haml</a>. These templates remove all the syntax overhead that is inherent to HTML's tag based notation and also allow the inline specification of dynamic elements. Typically, these elements are written in a dynamic scripting language (JavaScript in case of Pug).
 
 			p In vibe.d, however, templates can contain embedded D code. The templates are read and parsed while the application is being compiled and optimized D code is generated for them. This means that the runtime overhead for those templates is non-existent - there are no disk accesses, no parsing and there is no string copying involved because all of this has already been done before the application has even started.
 

--- a/views/templates.dt
+++ b/views/templates.dt
@@ -58,15 +58,15 @@ block vibed.body
 
 		p(style="color: red") Work-in-progress
 		p(style="color: red") Please use the
-			a(href="https://github.com/visionmedia/jade") Jade documentation
-			| for any section that is not filled with content, Diet templates are kept as compatible as possible to Jade templates.
+			a(href="https://github.com/pugjs/pug") Pug documentation
+			| for any section that is not filled with content, Diet templates are kept as compatible as possible to Pug templates.
 
 		p Diet templates are HTML templates which are statically compiled down to native D code. Dynamic pages thus have almost no runtime overhead and are often even faster than static pages on disk, because they are just written directly from RAM to the HTTP connection.
 
 		p The syntax equals that of
-			a(href="http://jade-lang.com") Jade
+			a(href="https://pugjs.org") Pug
 			| templates with the exception of some of the advanced syntax features. Since there is no official syntax reference written yet, you can use the
-			a(href="https://github.com/visionmedia/jade") Jade documentation
+			a(href="https://github.com/pugjs/pug") Pug documentation
 			| as a replacement. The main difference is that you write D expressions and statements instead of JavaScript.
 
 	section
@@ -404,7 +404,7 @@ block vibed.body
 		section
 			h2#functions Functions
 
-			p In any place where normal HTML tags are allowed, it is also possible to define functions in standard D syntax. All child tags will be output whenever the function is called. This functionality is very similar to the "mixin" feature of Jade.
+			p In any place where normal HTML tags are allowed, it is also possible to define functions in standard D syntax. All child tags will be output whenever the function is called. This functionality is very similar to the "mixin" feature of Pug.
 
 			pre.code.
 				- void css(string file)


### PR DESCRIPTION
Jade has undergone a name change and is now known as pug (or pugjs)