### PR TITLE
Add missing space

### DIFF
--- a/views/home.dt
+++ b/views/home.dt
@@ -8,7 +8,7 @@ block vibed.plainbody
 
 	a#forkme(href="https://github.com/rejectedsoftware/vibe.d")
 		img(src="images/github-banner.png",alt="fork vibe.d on github",style="position:absolute; top: 0; right: 0;")
-	p#slogan Asynchronous I/O that doesn’t get in your way, written in
+	p#slogan Asynchronous I/O that doesn’t get in your way, written in&#32;
 		a(href="http://dlang.org", target="_blank") D
 
 	.bs-columns3


### PR DESCRIPTION
This turns “Asynchronous I/O that doesn’t get in your way, written inD” into “Asynchronous I/O that doesn’t get in your way, written in D”. Since trailing spaces are supposed to be trimmed (via .editorconfig), I went for `&#32;`.