### PR TITLE
Fixed ugly line in header

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -10,6 +10,10 @@
 	padding-bottom: 2pt;
 }
 
+.logo-title-link {
+	text-decoration: none;
+}
+
 .dub-logo {
 	background-image: url(../images/dub-logo.png);
 	width: 56px;

--- a/views/vibed.inc.header.dt
+++ b/views/vibed.inc.header.dt
@@ -1,6 +1,6 @@
 #logo-line
 	- auto latest = req.params["latestRelease"];
-	a(href="https://vibed.org/")
+	a.logo-title-link(href="https://vibed.org/")
 		img#logo(src="#{req.rootDir}images/logo.png", alt='vibe.d logo')>
 		img#title(src="#{req.rootDir}images/title.png", alt='vibe.d beta banner')
 	a.download-button(href="https://code.dlang.org/packages/vibe-d/#{latest}")


### PR DESCRIPTION
Before:
![https://i.webfreak.org/fGKqAE](https://i.webfreak.org/fGKqAE)

After:
![https://i.webfreak.org/fGMgPS](https://i.webfreak.org/fGMgPS)

It was the underline decoration of the space because of a link